### PR TITLE
Add option do discard test suite

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,2 +1,7 @@
 cmake_minimum_required (VERSION 3.1 FATAL_ERROR)
+
+if (NOT DEFINED RUN_TEST_SUITE)
+option (RUN_TEST_SUITE "run test suite after install" ON)
+endif (NOT DEFINED RUN_TEST_SUITE)
+
 add_subdirectory(Source/GmmLib)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required (VERSION 3.1 FATAL_ERROR)
 
-if (NOT DEFINED RUN_TEST_SUITE)
-option (RUN_TEST_SUITE "run test suite after install" ON)
-endif (NOT DEFINED RUN_TEST_SUITE)
+if (NOT DEFINED MEDIA_RUN_TEST_SUITE)
+option (MEDIA_RUN_TEST_SUITE "run test suite after install" ON)
+endif (NOT DEFINED MEDIA_RUN_TEST_SUITE)
 
 add_subdirectory(Source/GmmLib)

--- a/Source/GmmLib/CMakeLists.txt
+++ b/Source/GmmLib/CMakeLists.txt
@@ -544,7 +544,7 @@ if(ARCH EQUAL 32)
 	endif()
 endif()
 
-if(RUN_TEST_SUITE)
-add_subdirectory(ULT)
-endif(RUN_TEST_SUITE)
+if(MEDIA_RUN_TEST_SUITE)
+	add_subdirectory(ULT)
+endif(MEDIA_RUN_TEST_SUITE)
 

--- a/Source/GmmLib/CMakeLists.txt
+++ b/Source/GmmLib/CMakeLists.txt
@@ -544,4 +544,7 @@ if(ARCH EQUAL 32)
 	endif()
 endif()
 
+if(RUN_TEST_SUITE)
 add_subdirectory(ULT)
+endif(RUN_TEST_SUITE)
+


### PR DESCRIPTION
Setup a new option to avoid test suite run after install in order to allow cross compilation.
Append `-DTEST_SUITE_RUN=OFF` to the **CMake** command line.

See https://github.com/intel/media-driver/pull/135
https://github.com/intel/media-driver/issues/108