### PR TITLE
Clean up mocs table build path

### DIFF
--- a/Source/GmmLib/CMakeLists.txt
+++ b/Source/GmmLib/CMakeLists.txt
@@ -154,35 +154,21 @@ MESSAGE("SourceConfiguration:")
 MESSAGE("CommonDir: ${BS_DIR_COMMON}")
 MESSAGE("IncDir: ${BS_DIR_INC}")
 
-# If we use GMM_REQUIRE_MESA_MOCS, and the MESA MOCS are not found, fail the
-# build instead of doing fallback to GMM defined values. It's required to
-# specify LIBDRM_SRC explicitly.
-if (DEFINED GMM_REQUIRE_MESA_MOCS)
-        if (NOT DEFINED GMM_LIBDRM_SRC)
-                message(FATAL_ERROR "Libdrm path not specified")
-        endif()
-
-        if (NOT EXISTS "${GMM_LIBDRM_SRC}/intel/intel_mocs_table.h")
-                message(FATAL_ERROR "MOCS not found in libdrm")
-        endif()
+# If '-DGMM_DYNAMIC_MOCS_TABLE=TRUE' (default is FALSE) passed to cmake
+# configure command gmmlib will generate MOCS table dynamically depending on
+# usage requests (Gen9+). In this case on Linux user responisbility is to
+# make sure that generated MOCS table is programmed on KMD level.
+if (GMM_DYNAMIC_MOCS_TABLE)
+    MESSAGE("MOCS table: dynamic")
+    add_definitions(-DGMM_DYNAMIC_MOCS_TABLE)
+else()
+    MESSAGE("MOCS table: static")
 endif()
 
 if(DEFINED UFO_DRIVER_OPTIMIZATION_LEVEL)
     if(${UFO_DRIVER_OPTIMIZATION_LEVEL} GREATER 0)
         add_definitions(-DGMM_GFX_GEN=${GFXGEN})
     endif()
-endif()
-
-# Includes are searched left-to-right, cmake add_definitions is appending,
-# if both files exist, user specified location (GMM_LIBDRM_SRC) will be used.
-if (EXISTS "${GMM_LIBDRM_SRC}/intel/intel_mocs_table.h")
-   add_definitions(-DHAVE_MESA_MOCS)
-   include_directories(${GMM_LIBDRM_SRC}/intel/)
-endif()
-
-if (EXISTS "/usr/include/libdrm/intel_mocs_table.h")
-        add_definitions(-DHAVE_MESA_MOCS)
-        include_directories(/usr/include/libdrm)
 endif()
 
 set(HEADERS_

--- a/Source/GmmLib/CachePolicy/GmmGen9CachePolicy.cpp
+++ b/Source/GmmLib/CachePolicy/GmmGen9CachePolicy.cpp
@@ -23,14 +23,6 @@ OTHER DEALINGS IN THE SOFTWARE.
 #include "Internal/Common/GmmLibInc.h"
 #include "External/Common/GmmCachePolicy.h"
 
-#ifdef HAVE_MESA_MOCS
-#include <intel_mocs_table.h>
-#endif
-
-#if defined(__linux__) && !defined(HAVE_MESA_MOCS)
-#define I915_GEN9_MOCS
-#endif
-
 //=============================================================================
 //
 // Function: __GmmGen9InitCachePolicy
@@ -48,7 +40,7 @@ GMM_STATUS GmmLib::GmmGen9CachePolicy::InitCachePolicy()
 
     __GMM_ASSERTPTR(pCachePolicy, GMM_ERROR);
 
-#if !defined(I915_GEN9_MOCS)
+#if defined(GMM_DYNAMIC_MOCS_TABLE)
 #define DEFINE_CACHE_ELEMENT(usage, llc, ellc, l3, age, i915) DEFINE_CP_ELEMENT(usage, llc, ellc, l3, 0, age, 0, 0, 0, 0, 0, 0, 0, 0)
 #else
 // i915 only supports three GEN9 MOCS entires:
@@ -91,40 +83,10 @@ GMM_STATUS GmmLib::GmmGen9CachePolicy::InitCachePolicy()
         uint32_t                      CurrentMaxIndex        = 0;
         GMM_CACHE_POLICY_TBL_ELEMENT *pCachePolicyTlbElement = pGmmGlobalContext->GetCachePolicyTlbElement();
 
-#ifdef HAVE_MESA_MOCS
-        // Index 0 is (traditionally) uncached but here we use the entries of the MESA MOCS table
-        {
-            GMM_CACHE_POLICY_TBL_ELEMENT *    Entry    = &(pCachePolicyTlbElement[0]);
-            uint32_t                          i        = 0;
-            uint32_t                          MESASize = 0;
-            const struct drm_i915_mocs_entry *m        = NULL;
-
-            if(pGmmGlobalContext->GetPlatformInfo().Platform.eProductFamily == IGFX_BROXTON ||
-               pGmmGlobalContext->GetPlatformInfo().Platform.eProductFamily == IGFX_GEMINILAKE)
-            {
-                MOCS_DEF_broxton_mocs_table; // Defines MESA_MOCS[]
-                m        = &(MESA_MOCS[0]);
-                MESASize = (sizeof(MESA_MOCS) / sizeof(struct drm_i915_mocs_entry));
-            }
-            else
-            {
-                MOCS_DEF_skylake_mocs_table; // Defines MESA_MOCS[]
-                m        = &(MESA_MOCS[0]);
-                MESASize = (sizeof(MESA_MOCS) / sizeof(struct drm_i915_mocs_entry));
-            }
-            for(i = 0; i < MESASize; i++)
-            {
-                Entry[i].LeCC.DwordValue = m[i].control_value;
-                Entry[i].L3.UshortValue  = m[i].l3cc_value;
-            }
-            // Track the last indexed used
-            CurrentMaxIndex = MESASize - 1;
-        }
-#else // First entries for !MESA_MOCS
         {
             bool LLC = (pGmmGlobalContext->GetGtSysInfo()->LLCCacheSizeInKb > 0); // aka "Core -vs- Atom".
 
-#if !defined(I915_GEN9_MOCS)
+#if defined(_WIN32)
             {
                 pCachePolicyTlbElement[0].L3.Cacheability   = L3_UNCACHEABLE;
                 pCachePolicyTlbElement[0].LeCC.Cacheability = LeCC_UNCACHEABLE;
@@ -154,7 +116,6 @@ GMM_STATUS GmmLib::GmmGen9CachePolicy::InitCachePolicy()
             }
 #endif
         }
-#endif
 
         // Process the cache policy and fill in the look up table
         for(uint32_t Usage = 0; Usage < GMM_RESOURCE_USAGE_MAX; Usage++)
@@ -189,7 +150,7 @@ GMM_STATUS GmmLib::GmmGen9CachePolicy::InitCachePolicy()
                 UsageEle.LeCC.LRUM         = 0;
                 UsageEle.LeCC.Cacheability = LeCC_UNCACHEABLE; // To avoid side effects use 01b even though 01b(UC) 11b(WB) are equivalent option
 
-#if !defined(I915_GEN9_MOCS)
+#if defined(GMM_DYNAMIC_MOCS_TABLE)
                 UsageEle.LeCC.TargetCache = TC_LLC; // No LLC for Broxton, but we still set it to LLC since it is needed for IA coherency cases
 #else
                 UsageEle.LeCC.TargetCache = TC_LLC_ELLC; // To match I915_GEN9_MOCS[0]

--- a/Source/GmmLib/inc/External/Common/GmmCachePolicyCommon.h
+++ b/Source/GmmLib/inc/External/Common/GmmCachePolicyCommon.h
@@ -25,6 +25,10 @@ OTHER DEALINGS IN THE SOFTWARE.
 #include "GmmMemAllocator.hpp"
 #include "GmmResourceInfoExt.h"
 
+#if defined(_WIN32)
+    #define GMM_DYNAMIC_MOCS_TABLE
+#endif
+
 /////////////////////////////////////////////////////////////////////////////////////
 /// @file GmmCachePolicyCommon.h
 /// @brief This file contains Gmm Cache Policy functions


### PR DESCRIPTION
This change aliminates (reduces) possibility to accidently build gmmlib
incompatible with the underlying kernel. The following build options
are removed since they confuse end-users:
  - GMM_REQUIRE_MESA_MOCS
  - GMM_LIBDRM_SRC
The following build option was added:
  - GMM_DYNAMIC_MOCS_TABLE=TRUE|FALSE (default: FALSE)

By default, gmmlib will:
  - on Linux it will work on the upstream kernel mocs settings utilizing
  static mocs table
  - on Windows it will generate dynamic mocs table depending on the incoming
  usage requests (GMM_DYNAMIC_MOCS_TABLE forced to TRUE in the source code)

If user will configure build as follows:
  mkdir build && cmake GMM_DYNAMIC_MOCS_TABLE=TRUE ..
gmmlib will generate dynamic mocs table depending on the incoming usage
requests. User responsibility is to program mocs table in the kernel mode
driver correspondigly (on Linux).

Fixes: #8

Signed-off-by: Dmitry Rogozhkin <dmitry.v.rogozhkin@intel.com>