### PR TITLE
Build dynamic library with a linux-qualified name

### DIFF
--- a/Source/GmmLib/CMakeLists.txt
+++ b/Source/GmmLib/CMakeLists.txt
@@ -22,6 +22,19 @@
 
 cmake_minimum_required(VERSION 3.5)
 project(igfx_gmmumd)
+
+if(NOT DEFINED MAJOR_VERSION)
+    set(MAJOR_VERSION 1)
+endif()
+
+if(NOT DEFINED MINOR_VERSION)
+    set(MINOR_VERSION 0)
+endif()
+
+if(NOT DEFINED PATCH_VERSION)
+    set(PATCH_VERSION 0)
+endif()
+
 if(NOT DEFINED BS_USE_OSDM_BUILD_SYSTEM)
     if(DEFINED ENV{BS_USE_OSDM_BUILD_SYSTEM})
         set(BS_USE_OSDM_BUILD_SYSTEM "$ENV{BS_USE_OSDM_BUILD_SYSTEM}")
@@ -397,7 +410,8 @@ target_link_libraries( ${GMM_LIB_DLL_NAME}
         )
 else()
 	set_target_properties(${GMM_LIB_DLL_NAME} PROPERTIES OUTPUT_NAME "igdgmm")
-
+	set_target_properties(${GMM_LIB_DLL_NAME} PROPERTIES VERSION ${MAJOR_VERSION}.${MINOR_VERSION}.${PATCH_VERSION})
+	set_target_properties(${GMM_LIB_DLL_NAME} PROPERTIES SOVERSION ${MAJOR_VERSION})
 endif()
 
 
@@ -526,18 +540,6 @@ endif()
 
 if(UNIX)
     include(GNUInstallDirs)
-
-    if(NOT DEFINED MAJOR_VERSION)
-        set(MAJOR_VERSION 0)
-    endif()
-
-    if(NOT DEFINED MINOR_VERSION)
-        set(MINOR_VERSION 1)
-    endif()
-
-    if(NOT DEFINED PATCH_VERSION)
-        set(PATCH_VERSION 0)
-    endif()
 
     configure_file(${BS_DIR_GMMLIB}/igdgmm.h.in ${CMAKE_BINARY_DIR}/igdgmm.h)
     configure_file(${BS_DIR_GMMLIB}/igdgmm.pc.in ${CMAKE_BINARY_DIR}/igdgmm.pc @ONLY)


### PR DESCRIPTION
Fixes: #28

By convention on Linux if library is going to be linked against it should have:
 * real name, which is usually libigdgmm.so.x.y.z, x.y.z is a library version
 * soname which is libigdgmm.so.x, usually that's a symbolic link to real name
 * linker name which is libigdgmm.so, usually that's a symbolic link to soname
Building library without the above convention is applicable only if library is
supposed to be dlopen(), i.e. for drivers and similar things.

Since gmmlib will be linked against rahter than dlopen-ed it should qualify to
the above Linux convention. This fix makes exactly that. CMake will automatically
create required symbolc links (soname and linker name).

Signed-off-by: Dmitry Rogozhkin <dmitry.v.rogozhkin@intel.com>