### PR TITLE
Decrement context refcount on Linux on Destroy

### DIFF
--- a/Source/GmmLib/GlobalInfo/GmmInfo.cpp
+++ b/Source/GmmLib/GlobalInfo/GmmInfo.cpp
@@ -141,6 +141,9 @@ extern "C" GMM_STATUS GMM_STDCALL GmmCreateSingletonContext(const PLATFORM Platf
 extern "C" void GMM_STDCALL GmmDestroySingletonContext(void)
 {
     __GMM_ASSERTPTR(pGmmGlobalContext, VOIDRETURN);
+#ifndef _WIN32
+    GmmLib::Context::DecrementRefCount();
+#endif
     // Dont delete/destruct singletonContext. This is needed so that SingletonContext is not
     // deleted even after UMDs are unloaded and process is still active.
     // Free of SingletonContext shall be handled as part of process clean up


### PR DESCRIPTION
Fixes #27

Without this change the following ULT tests fail on media-driver side:
[  FAILED  ] 2 tests, listed below:
[  FAILED  ] MediaDecodeDdiTest.DecodeHEVCLong
[  FAILED  ] MediaEncodeDdiTest.EncodeHEVC_DualPipe

Signed-off-by: Dmitry Rogozhkin <dmitry.v.rogozhkin@intel.com>