### PR TITLE
Integrate ULT into cmake's test framework 

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,4 +4,5 @@ if (NOT DEFINED RUN_TEST_SUITE)
 option (RUN_TEST_SUITE "run test suite after install" ON)
 endif (NOT DEFINED RUN_TEST_SUITE)
 
+enable_testing()
 add_subdirectory(Source/GmmLib)

--- a/README.rst
+++ b/README.rst
@@ -34,7 +34,9 @@ Building
 
 4) cmake [-DCMAKE_BUILD_TYPE= Release | Debug | ReleaseInternal] [-DARCH= 64 | 32]  ..
 
-5) $ make -j8 ( Also performs compile time ULT)
+5) $ make -j8
+
+6) $ make test (Performs ULT)
 
  
 Install

--- a/Source/GmmLib/ULT/CMakeLists.txt
+++ b/Source/GmmLib/ULT/CMakeLists.txt
@@ -121,11 +121,7 @@ target_link_libraries(${EXE_NAME}
     dl
 )
 
-add_custom_target(Run_ULT ALL DEPENDS GMMULT)
-
-add_custom_command(
-    TARGET Run_ULT
-    POST_BUILD
-    COMMAND echo running ULTs
-    COMMAND "${CMAKE_COMMAND}" -E env "LD_LIBRARY_PATH=$<TARGET_FILE_DIR:igfx_gmmumd_dll>" ${CMAKE_CFG_INTDIR}/${EXE_NAME} --gtest_filter=CTest*
+add_test(
+    NAME ULT
+    COMMAND env "LD_LIBRARY_PATH=$<TARGET_FILE_DIR:igfx_gmmumd_dll>" $<TARGET_FILE:${EXE_NAME}> --gtest_filter=CTest*
 )


### PR DESCRIPTION
cmake comes with a test framework, so let's make use of it. With this change the build system also works better with common packaging tools for distros, e.g. Debian's cmake support in debhelper.