### PR TITLE
Fixing API versioning as 11.1

### DIFF
--- a/Source/GmmLib/CMakeLists.txt
+++ b/Source/GmmLib/CMakeLists.txt
@@ -24,15 +24,15 @@ cmake_minimum_required(VERSION 3.5)
 project(igfx_gmmumd)
 
 # GmmLib Api Version used for so naming
-set(GMMLIB_API_MAJOR_VERSION 12)
-set(GMMLIB_API_MINOR_VERSION 0)
+set(GMMLIB_API_MAJOR_VERSION 11)
+set(GMMLIB_API_MINOR_VERSION 1)
 
 if(NOT DEFINED MAJOR_VERSION)
-	set(MAJOR_VERSION 12)
+	set(MAJOR_VERSION 11)
 endif()
 
 if(NOT DEFINED MINOR_VERSION)
-	set(MINOR_VERSION 0)
+	set(MINOR_VERSION 1)
 endif()
 
 if(NOT DEFINED PATCH_VERSION)

--- a/Source/GmmLib/inc/External/Common/GmmLibDllName.h
+++ b/Source/GmmLib/inc/External/Common/GmmLibDllName.h
@@ -29,7 +29,7 @@ OTHER DEALINGS IN THE SOFTWARE.
     #if defined(_WIN64)
         #define GMM_UMD_DLL     "igdgmm64.dll"
     #else
-        #define GMM_UMD_DLL     "libigdgmm.so.12"
+        #define GMM_UMD_DLL     "libigdgmm.so.11"
     #endif
 #else
     #define GMM_ENTRY_NAME      "_OpenGmm@4"
@@ -40,6 +40,6 @@ OTHER DEALINGS IN THE SOFTWARE.
     #if defined(_WIN32)
         #define GMM_UMD_DLL     "igdgmm32.dll"
     #else
-        #define GMM_UMD_DLL     "libigdgmm.so.12"
+        #define GMM_UMD_DLL     "libigdgmm.so.11"
     #endif
 #endif


### PR DESCRIPTION
Major API version was incorrectly bumped to 12 while there was no
ABI changes. This commit gets it back to 11 and bumps minor version
instead.

Fixes: 94306f5 ("Initial Multi adapter changes")

Signed-off-by: Dmitry Rogozhkin <dmitry.v.rogozhkin@intel.com>