### PR TITLE
Fix BUILD_TYPE=debug on Linux: -D_DEBUG isn't passed

### DIFF
--- a/Source/GmmLib/CMakeLists.txt
+++ b/Source/GmmLib/CMakeLists.txt
@@ -417,13 +417,13 @@ include(Linux.cmake)
 # create dll library
 ###################################################################################
 add_library( ${GMM_LIB_DLL_NAME} SHARED igdgmm.rc ${UMD_SOURCES} ${UMD_HEADERS})
+GmmLibSetTargetConfig( ${GMM_LIB_DLL_NAME} )
 
 if(MSVC)
 
 set_target_properties(${GMM_LIB_DLL_NAME} PROPERTIES OUTPUT_NAME "igdgmm${GMMLIB_ARCH}")
 
 bs_set_wdk(${GMM_LIB_DLL_NAME})
-GmmLibSetTargetConfig( ${GMM_LIB_DLL_NAME} )
 
 set_target_properties(${GMM_LIB_DLL_NAME} PROPERTIES VS_GLOBAL_DriverTargetPlatform Universal)
 set_target_properties(${GMM_LIB_DLL_NAME} PROPERTIES VS_PLATFORM_TOOLSET WindowsApplicationForDrivers10.0)
@@ -463,10 +463,6 @@ bs_set_extra_target_properties(${GMM_LIB_DLL_NAME}
 	  __UMD
 	  GMM_UNIFY_DAF_API
 	  )
-
-if(CMAKE_BUILD_TYPE STREQUAL "ReleaseInternal")
-	bs_set_extra_target_properties(${GMM_LIB_DLL_NAME} _RELEASE_INTERNAL)
-endif()
 
 target_include_directories(${GMM_LIB_DLL_NAME} INTERFACE
         ${BS_DIR_GMMLIB}/inc


### PR DESCRIPTION
`_DEBUG` is used in a number of files e.g., to enable runtime checks.
https://github.com/intel/gmmlib/search?q=_DEBUG+language%3Ac+language%3Ac%2B%2B
