### PR TITLE
Fix uninitialized ExpectedQPitch warnings

### DIFF
--- a/Source/GmmLib/ULT/GmmGen12ResourceULT.cpp
+++ b/Source/GmmLib/ULT/GmmGen12ResourceULT.cpp
@@ -2324,7 +2324,7 @@ TEST_F(CTestGen12Resource, DISABLED_TestDepthCompressedResource)
             VerifyResourcePitch<true>(ResourceInfo, ExpectedPitch);
             VerifyResourcePitchInTiles<true>(ResourceInfo, 4); // 2 tile wide
 
-            uint32_t TwoDQPitch, ExpectedQPitch;
+            uint32_t TwoDQPitch, ExpectedQPitch = 0u;
             if(gmmParams.Type == RESOURCE_3D)
             {
                 TwoDQPitch     = GMM_ULT_ALIGN(gmmParams.BaseHeight, VAlign);

--- a/Source/GmmLib/ULT/GmmGen12dGPUResourceULT.cpp
+++ b/Source/GmmLib/ULT/GmmGen12dGPUResourceULT.cpp
@@ -2329,7 +2329,7 @@ TEST_F(CTestGen12dGPUResource, DISABLED_TestDepthCompressedResource)
             VerifyResourcePitch<true>(ResourceInfo, ExpectedPitch);
             VerifyResourcePitchInTiles<true>(ResourceInfo, 4); // 2 tile wide
 
-            uint32_t TwoDQPitch, ExpectedQPitch;
+            uint32_t TwoDQPitch, ExpectedQPitch = 0u;
             if(gmmParams.Type == RESOURCE_3D)
             {
                 TwoDQPitch     = GMM_ULT_ALIGN(gmmParams.BaseHeight, VAlign);


### PR DESCRIPTION
When building gmmlib 20.3.2 in Chrome OS we observe the following
uninitialized warnings. Fixes #74.

```
/build/volteer/tmp/portage/media-libs/gmmlib-20.3.2-r2/work/gmmlib-intel-gmmlib-20.3.2/Source/GmmLib/ULT/GmmGen12dGPUResourceULT.cpp:2343:73: warning: variable 'ExpectedQPitch' is uninitialized when used here [-Wuninitialized]
                                          ExpectedPitch * GMM_ULT_ALIGN(ExpectedQPitch, AllocTileSize[0][1]) :
                                                                        ^~~~~~~~~~~~~~

/build/volteer/tmp/portage/media-libs/gmmlib-20.3.2-r2/work/gmmlib-intel-gmmlib-20.3.2/Source/GmmLib/ULT/GmmGen12ResourceULT.cpp:2338:73: warning: variable 'ExpectedQPitch' is uninitialized when used here [-Wuninitialized]
                                          ExpectedPitch * GMM_ULT_ALIGN(ExpectedQPitch, AllocTileSize[0][1]) :
                                                                        ^~~~~~~~~~~~~~
```