### PR TITLE
Initialize PageTable NodesPerTable in order

### DIFF
--- a/Source/GmmLib/TranslationTable/GmmUmdTranslationTable.h
+++ b/Source/GmmLib/TranslationTable/GmmUmdTranslationTable.h
@@ -453,8 +453,8 @@ namespace GmmLib
         GmmClientContext    *pClientContext;
 
         PageTable(int Size, int NumL3e, TT_TYPE flag) :
-            NodesPerTable(Size / PAGE_SIZE),
-            TTType(flag)
+            TTType(flag),
+            NodesPerTable(Size / PAGE_SIZE)
         {
             InitializeCriticalSection(&TTLock);
 


### PR DESCRIPTION
This commit addresses the following warning. Closes #80.
```
warning: field 'NodesPerTable' will be initialized after field 'TTType' [-Wreorder-ctor]
TranslationTable/../TranslationTable/GmmUmdTranslationTable.h:456:13:
            NodesPerTable(Size / PAGE_SIZE),
            ^
```