### PR TITLE
Fix null conversion and arithmetic warning

### DIFF
--- a/Source/GmmLib/TranslationTable/GmmPageTableMgr.cpp
+++ b/Source/GmmLib/TranslationTable/GmmPageTableMgr.cpp
@@ -408,11 +408,11 @@ ERROR_CASE:
 /////////////////////////////////////////////////////////////////////////////////////
 /// Returns Root-table address for Aux-table
 ///
-/// @return     GMM_GFX_ADDRESS if Aux-Table was created; NULL otherwise
+/// @return     GMM_GFX_ADDRESS if Aux-Table was created; 0 otherwise
 /////////////////////////////////////////////////////////////////////////////////////
 GMM_GFX_ADDRESS GmmLib::GmmPageTableMgr::GetAuxL3TableAddr()
 {
-    return AuxTTObj ? AuxTTObj->GetL3Address() : NULL;
+    return AuxTTObj ? AuxTTObj->GetL3Address() : 0;
 }
 
 /////////////////////////////////////////////////////////////////////////////////////
@@ -471,7 +471,7 @@ GMM_STATUS GmmLib::GmmPageTableMgr::InitContextAuxTableRegister(HANDLE CmdQHandl
 /////////////////////////////////////////////////////////////////////////////////////
 GMM_STATUS GmmLib::GmmPageTableMgr::UpdateAuxTable(const GMM_DDI_UPDATEAUXTABLE *UpdateReq)
 {
-    if(GetAuxL3TableAddr() == NULL)
+    if(!GetAuxL3TableAddr())
     {
         GMM_ASSERTDPF(0, "Invalid AuxTable update request, AuxTable is not initialized");
         return GMM_INVALIDPARAM;


### PR DESCRIPTION
```
warning: implicit conversion of NULL constant to 'unsigned long' [-Wnull-conversion]
Source/GmmLib/TranslationTable/GmmPageTableMgr.cpp:415:50:
    return AuxTTObj ? AuxTTObj->GetL3Address() : NULL;
    ~~~~~~                                       ^~~~
                                                 0

warning: comparison between NULL and non-pointer ('GMM_GFX_ADDRESS' (aka 'unsigned long') and NULL) [-Wnull-arithmetic]
Source/GmmLib/TranslationTable/GmmPageTableMgr.cpp:474:28:
    if(GetAuxL3TableAddr() == NULL)
       ~~~~~~~~~~~~~~~~~~~ ^  ~~~~
```