### PR TITLE
Fix ULT TEST_BPP comparison

### DIFF
--- a/Source/GmmLib/ULT/GmmGen12ResourceULT.cpp
+++ b/Source/GmmLib/ULT/GmmGen12ResourceULT.cpp
@@ -2114,7 +2114,7 @@ TEST_F(CTestGen12Resource, TestLinearCompressedResource)
         gmmParams.Format                         = SetResourceFormat(bpp);
         gmmParams.BaseWidth64                    = 0x1;
         gmmParams.BaseHeight                     = 1;
-        gmmParams.Flags.Info.AllowVirtualPadding = (bpp != 8); //OCL uses 8bpp buffers. doc doesn't comment if Linear buffer compr allowed or not on bpp!=8.
+        gmmParams.Flags.Info.AllowVirtualPadding = (bpp != TEST_BPP_8); //OCL uses 8bpp buffers. doc doesn't comment if Linear buffer compr allowed or not on bpp!=8.
 
         GMM_RESOURCE_INFO *ResourceInfo;
         ResourceInfo = pGmmULTClientContext->CreateResInfoObject(&gmmParams);
@@ -2159,7 +2159,7 @@ TEST_F(CTestGen12Resource, TestLinearCompressedResource)
         gmmParams.Format                         = SetResourceFormat(bpp);
         gmmParams.BaseWidth64                    = 0x1001;
         gmmParams.BaseHeight                     = 1;
-        gmmParams.Flags.Info.AllowVirtualPadding = (bpp != 8); //OCL uses 8bpp buffers. document doesn't comment if Linear buffer compr allowed or not on bpp!=8.
+        gmmParams.Flags.Info.AllowVirtualPadding = (bpp != TEST_BPP_8); //OCL uses 8bpp buffers. document doesn't comment if Linear buffer compr allowed or not on bpp!=8.
         gmmParams.Flags.Gpu.UnifiedAuxSurface    = 1;          //Turn off for separate aux creation
         gmmParams.Flags.Gpu.CCS                  = 1;
 

--- a/Source/GmmLib/ULT/GmmGen12dGPUResourceULT.cpp
+++ b/Source/GmmLib/ULT/GmmGen12dGPUResourceULT.cpp
@@ -2082,7 +2082,7 @@ TEST_F(CTestGen12dGPUResource, DISABLED_TestLinearCompressedResource)
         gmmParams.Format                         = SetResourceFormat(bpp);
         gmmParams.BaseWidth64                    = 0x1;
         gmmParams.BaseHeight                     = 1;
-        gmmParams.Flags.Info.AllowVirtualPadding = (bpp != 8); //OCL uses 8bpp buffers. Specification doesn't comment if Linear buffer compr allowed or not on bpp!=8.
+        gmmParams.Flags.Info.AllowVirtualPadding = (bpp != TEST_BPP_8); //OCL uses 8bpp buffers. Specification doesn't comment if Linear buffer compr allowed or not on bpp!=8.
 
         GMM_RESOURCE_INFO *ResourceInfo;
         ResourceInfo = pGmmULTClientContext->CreateResInfoObject(&gmmParams);
@@ -2127,7 +2127,7 @@ TEST_F(CTestGen12dGPUResource, DISABLED_TestLinearCompressedResource)
         gmmParams.Format                         = SetResourceFormat(bpp);
         gmmParams.BaseWidth64                    = 0x1001;
         gmmParams.BaseHeight                     = 1;
-        gmmParams.Flags.Info.AllowVirtualPadding = (bpp != 8); //OCL uses 8bpp buffers. Specification doesn't comment if Linear buffer compr allowed or not on bpp!=8.
+        gmmParams.Flags.Info.AllowVirtualPadding = (bpp != TEST_BPP_8); //OCL uses 8bpp buffers. Specification doesn't comment if Linear buffer compr allowed or not on bpp!=8.
         gmmParams.Flags.Gpu.UnifiedAuxSurface    = 1;          //Turn off for separate aux creation
         gmmParams.Flags.Gpu.CCS                  = 1;
 


### PR DESCRIPTION
This commit addresses the following warning. TestLinearCompressedResource is looping through TEST_BPP values (0, 1, 2, 3, 4). Comparing to 8 is outside of the available enum options. Closes #83.

```
warning: result of comparison of constant 8 with expression of type 'TEST_BPP' (aka 'TEST_BPP_ENUM') is always true [-Wtautological-constant-out-of-range-compare]
Source/GmmLib/ULT/GmmGen12ResourceULT.cpp:2117:57:
        gmmParams.Flags.Info.AllowVirtualPadding = (bpp != 8); //OCL uses 8bpp buffers. doc doesn't comment if Linear buffer compr allowed or not on bpp!=8.
                                                    ~~~ ^  ~
```