### PR TITLE
Fix overlapping comparison warning

### DIFF
--- a/Source/GmmLib/Texture/GmmGen9Texture.cpp
+++ b/Source/GmmLib/Texture/GmmGen9Texture.cpp
@@ -592,7 +592,7 @@ void GmmLib::GmmGen9TextureCalc::Fill2DTexOffsetAddress(GMM_TEXTURE_INFO *pTexIn
 	    
 	// Color Surf with MSAA Enabled Mutiply 4
         if(GMM_IS_64KB_TILE(pTexInfo->Flags) && (!pGmmGlobalContext->GetSkuTable().FtrTileY) &&
-           ((pTexInfo->MSAA.NumSamples == 8) && (pTexInfo->MSAA.NumSamples == 16)) &&
+           ((pTexInfo->MSAA.NumSamples == 8) || (pTexInfo->MSAA.NumSamples == 16)) &&
            ((pTexInfo->Flags.Gpu.Depth == 0) && (pTexInfo->Flags.Gpu.SeparateStencil == 0)))
         {
             ArrayQPitch *= 4; /* Aligned height of 4 samples */


### PR DESCRIPTION
NumSamples can not be 8 and 16 at the same time. Closes #87.

```
warning: overlapping comparisons always evaluate to false [-Wtautological-overlap-compare]
Source/GmmLib/Texture/GmmGen9Texture.cpp:595:46:
           ((pTexInfo->MSAA.NumSamples == 8) && (pTexInfo->MSAA.NumSamples == 16)) &&
            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```