### PR TITLE
CMakeLists.txt: add project in toplevel file

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,7 @@
 cmake_minimum_required (VERSION 3.1 FATAL_ERROR)
 
+project(gmmlib)
+
 if (NOT DEFINED RUN_TEST_SUITE)
 option (RUN_TEST_SUITE "run test suite after install" ON)
 endif (NOT DEFINED RUN_TEST_SUITE)


### PR DESCRIPTION
If not present, current cmake will complain:
CMake Warning (dev) in CMakeLists.txt:
  No project() command is present.  The top-level CMakeLists.txt file must
  contain a literal, direct call to the project() command.  Add a line of
  code such as

    project(ProjectName)

  near the top of the file, but after cmake_minimum_required().

  CMake is pretending there is a "project(Project)" command on the first
  line.
This warning is for project developers.  Use -Wno-dev to suppress it.

Signed-off-by: Conrad Kostecki <conikost@gentoo.org>