### PR TITLE
Remove '-Werror=non-virtual-dtor'

### DIFF
--- a/Source/GmmLib/Linux.cmake
+++ b/Source/GmmLib/Linux.cmake
@@ -74,7 +74,6 @@ else()
     -Wno-enum-compare
     -Werror=address
     -Werror=format-security
-    -Werror=non-virtual-dtor
     -Werror=return-type
 
     # General optimization options


### PR DESCRIPTION
Fix for warning during build.

  cc1: warning: '-Werror=' argument '-Werror=non-virtual-dtor' is not valid for C

Signed-off-by: Rudi Heitbaum <rudi@heitbaum.com>