### PR TITLE
Fix gcc12 build: out of bounds warning

### DIFF
--- a/Source/GmmLib/ULT/GmmMultiAdapterULT.cpp
+++ b/Source/GmmLib/ULT/GmmMultiAdapterULT.cpp
@@ -133,7 +133,6 @@ void MACommonULT::UnLoadGmmDll(uint32_t AdapterIdx, uint32_t CountIdx)
 
 void MACommonULT::GmmInitModule(uint32_t AdapterIdx, uint32_t CountIdx)
 {
-    ASSERT_TRUE(AdapterIdx < MAX_NUM_ADAPTERS);
     GMM_STATUS  Status                                  = GMM_SUCCESS;
     ADAPTER_BDF AdapterBDF                              = GetAdapterBDF(AdapterIdx);
     GfxPlatform[AdapterIdx][CountIdx].eProductFamily    = GetProductFamily(AdapterIdx);

--- a/Source/GmmLib/ULT/GmmMultiAdapterULT.cpp
+++ b/Source/GmmLib/ULT/GmmMultiAdapterULT.cpp
@@ -133,6 +133,7 @@ void MACommonULT::UnLoadGmmDll(uint32_t AdapterIdx, uint32_t CountIdx)
 
 void MACommonULT::GmmInitModule(uint32_t AdapterIdx, uint32_t CountIdx)
 {
+    ASSERT_TRUE(AdapterIdx < MAX_NUM_ADAPTERS);
     GMM_STATUS  Status                                  = GMM_SUCCESS;
     ADAPTER_BDF AdapterBDF                              = GetAdapterBDF(AdapterIdx);
     GfxPlatform[AdapterIdx][CountIdx].eProductFamily    = GetProductFamily(AdapterIdx);

--- a/Source/GmmLib/ULT/GmmResourceULT.cpp
+++ b/Source/GmmLib/ULT/GmmResourceULT.cpp
@@ -3331,6 +3331,7 @@ TEST_F(CTestResource, TestPlanar2D_IMC4)
             EXPECT_EQ(YHeight, ResourceInfo->GetPlanarYOffset(GMM_PLANE_U));
             EXPECT_EQ(YHeight, ResourceInfo->GetPlanarYOffset(GMM_PLANE_V));
         }
+        pGmmULTClientContext->DestroyResInfoObject(ResourceInfo);
     }
 }
 


### PR DESCRIPTION
gcc-12 will build with this warning:

GmmMultiAdapterULT.cpp:139:27: warning: array subscript 30 is above array bounds of ‘PLATFORM [9][3]’ {aka ‘PLATFORM_STR [9][3]’}

This fix adds an assert, guaranteeing that PlatformIdx will never be out of bounds, which will stop the gcc warning being triggered.