### PR TITLE
FileDescriptor field needs to be initialized before it is used.

### DIFF
--- a/Source/GmmLib/ULT/GmmCommonULT.cpp
+++ b/Source/GmmLib/ULT/GmmCommonULT.cpp
@@ -70,11 +70,12 @@ void CommonULT::SetUpTestCase()
 
     AllocateAdapterInfo();
 
-    InArgs.ClientType = GMM_EXCITE_VISTA;
-    InArgs.pGtSysInfo = &pGfxAdapterInfo->SystemInfo;
-    InArgs.pSkuTable  = &pGfxAdapterInfo->SkuTable;
-    InArgs.pWaTable   = &pGfxAdapterInfo->WaTable;
-    InArgs.Platform   = GfxPlatform;
+    InArgs.ClientType     = GMM_EXCITE_VISTA;
+    InArgs.pGtSysInfo     = &pGfxAdapterInfo->SystemInfo;
+    InArgs.pSkuTable      = &pGfxAdapterInfo->SkuTable;
+    InArgs.pWaTable       = &pGfxAdapterInfo->WaTable;
+    InArgs.Platform       = GfxPlatform;
+    InArgs.FileDescriptor = 0;
 #ifdef _WIN32
     InArgs.stAdapterBDF = {0, 2, 0, 0};
 #endif


### PR DESCRIPTION
This fixes issue #100 

Valgrind detects undefined behaviour, when a jump is made based on uninitialized data.
