### PR TITLE
Remove ARCH from build instructions

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -33,7 +33,7 @@ Building
 
 4) Run the cmake command to prepare build files
 
-   ``$ cmake [-DCMAKE_BUILD_TYPE= Release | Debug | ReleaseInternal] [-DARCH= 64 | 32]  ..``
+   ``$ cmake [-DCMAKE_BUILD_TYPE= Release | Debug | ReleaseInternal]  ..``
 
 5) Build the project
 


### PR DESCRIPTION
ARCH cmake option was removed back in 72c92c0dfa8c7d66cfbad26b96e3df8ddf5ff9ef.