### PR TITLE
More correct check before accessing by pointer 'mResInfo'

### DIFF
--- a/Source/GmmLib/ULT/GmmAuxTableULT.h
+++ b/Source/GmmLib/ULT/GmmAuxTableULT.h
@@ -87,13 +87,16 @@ public:
 
             mResInfo = pGmmULTClientContext->CreateResInfoObject(&gmmParams);
 
+            if(!mResInfo)
+                return false;
+
             size = mResInfo->GetSizeSurface();
 
             alignment = mResInfo->GetResFlags().Info.TiledYf ? GMM_KBYTE(16) : GMM_KBYTE(64);
 
             mBuf = aligned_alloc(alignment, ALIGN(size, alignment));
 
-            if(!mResInfo || !mBuf)
+            if(!mBuf)
                 return false;
 
             mYBase      = (GMM_GFX_ADDRESS)mBuf;


### PR DESCRIPTION
More correct check before accessing by pointer that can be nullptr, as well as in case NULL, earlier termination function without allocating memory in aligned_alloc() function.