### PR TITLE
Optimize structures for 64bit platforms and changed type MinWidth to uint32_t

### DIFF
--- a/Source/GmmLib/inc/External/Common/GmmPlatformExt.h
+++ b/Source/GmmLib/inc/External/Common/GmmPlatformExt.h
@@ -442,20 +442,20 @@ typedef struct GMM_TEXTURE_ALIGN_REC
 //---------------------------------------------------------------------------
 typedef struct __GMM_BUFFER_TYPE_REC
 {
-    uint32_t           Alignment;              // Base Address Alignment
+    GMM_GFX_SIZE_T     MinAllocationSize;      // Minimum Allocation size requirement
+    GMM_GFX_SIZE_T     MaxPitch;               // Maximum pitch
+    uint32_t           MinPitch;               // Minimum pitch
     uint32_t           PitchAlignment;         // Pitch Alignment restriction.
     uint32_t           RenderPitchAlignment;   // Pitch Alignment for render surface
     uint32_t           LockPitchAlignment;     // Pitch Alignment for locked surface
-    uint32_t           MinPitch;               // Minimum pitch
-    GMM_GFX_SIZE_T     MaxPitch;               // Maximum pitch
-    GMM_GFX_SIZE_T     MinAllocationSize;      // Minimum Allocation size requirement
+    uint32_t           Alignment;              // Base Address Alignment
 
-    uint32_t           MinHeight;              // Mininum height in bytes
-    GMM_GFX_SIZE_T     MinWidth;               // Minimum width in bytes
-    uint32_t           MinDepth;               // Minimum depth  (only for volume)
-    GMM_GFX_SIZE_T     MaxHeight;              // Maximum height in bytes
     GMM_GFX_SIZE_T     MaxWidth;               // Maximum Width in bytes
+    GMM_GFX_SIZE_T     MaxHeight;              // Maximum height in bytes
+    uint32_t           MinWidth;               // Minimum width in bytes
+    uint32_t           MinHeight;              // Mininum height in bytes
     uint32_t           MaxDepth;               // Maximum depth  (only for volume)
+    uint32_t           MinDepth;               // Minimum depth  (only for volume)
     uint32_t           MaxArraySize;
     uint8_t            NeedPow2LockAlignment;  // Locking surface need to be power of 2 aligned
 } __GMM_BUFFER_TYPE;

--- a/Source/GmmLib/inc/External/Common/GmmResourceInfoExt.h
+++ b/Source/GmmLib/inc/External/Common/GmmResourceInfoExt.h
@@ -381,8 +381,8 @@ typedef struct GMM_RESCREATE_CUSTOM_PARAMS_2_REC : public GMM_RESCREATE_CUSTOM_P
 {
     struct
     {
-        uint32_t       Pitch;
         GMM_GFX_SIZE_T Size;
+        uint32_t       Pitch;
         uint32_t       BaseAlignment;
         struct
         {


### PR DESCRIPTION
This PR aligns fields structures, this PR reduces size structure, which greatly affects when copying an object or moving it. Fields are aligned to be readable as before. And I also replaced minWidth with uint32_t, I think 64-bit unsigned int will be superfluous here, and also uint32_t was specified for minHeight.