### PR TITLE
Removed excess checks before delete/free and remove unused vars

### DIFF
--- a/Source/GmmLib/GlobalInfo/GmmClientContext.cpp
+++ b/Source/GmmLib/GlobalInfo/GmmClientContext.cpp
@@ -750,10 +750,7 @@ GMM_PAGETABLE_MGR* GMM_STDCALL GmmLib::GmmClientContext::CreatePageTblMgrObject(
 /////////////////////////////////////////////////////////////////////////////////////
 void GMM_STDCALL GmmLib::GmmClientContext::DestroyPageTblMgrObject(GMM_PAGETABLE_MGR* pPageTableMgr)
 {
-    if (pPageTableMgr)
-    {
-        delete pPageTableMgr;
-    }
+    delete pPageTableMgr;
 }
 
 #ifdef GMM_LIB_DLL

--- a/Source/GmmLib/TranslationTable/GmmPageTableMgr.cpp
+++ b/Source/GmmLib/TranslationTable/GmmPageTableMgr.cpp
@@ -697,14 +697,8 @@ GmmLib::GmmPageTableMgr::~GmmPageTableMgr()
 
         if(AuxTTObj)
         {
-            if(AuxTTObj->NullL1Table)
-            {
-                delete AuxTTObj->NullL1Table;
-            }
-            if(AuxTTObj->NullL2Table)
-            {
-                delete AuxTTObj->NullL2Table;
-            }
+            delete AuxTTObj->NullL1Table;
+            delete AuxTTObj->NullL2Table;
             AuxTTObj->DestroyL3Table();
             delete AuxTTObj;
             AuxTTObj = NULL;

--- a/Source/GmmLib/ULT/GmmGen12ResourceULT.cpp
+++ b/Source/GmmLib/ULT/GmmGen12ResourceULT.cpp
@@ -2839,17 +2839,6 @@ TEST_F(CTestGen12Resource, Test2DTileYfAMFSResource)
 /// @brief ULT for MSAA Resource - TODO adddepth MSAA, MCS surf param verificaton, compression case
 TEST_F(CTestGen12Resource, TestColorMSAA)
 {
-    //Tile dimensions in Bytes
-    const uint32_t MCSTileSize[1][2] = {128, 32}; //MCS is TileY
-
-    const uint32_t TestDimensions[4][2] = {
-    //Input dimensions in #Tiles
-    {15, 20}, //16 Tiles x 20 <Max Width: Depth MSS crosses Pitch limit beyond this>
-    {0, 0},   //1x1x1
-    {1, 0},   //2 Tilesx1
-    {1, 1},   //2 Tiles x 2
-    };
-
     uint32_t TestArraySize[2] = {1, 5};
     uint32_t MinPitch         = 32;
 

--- a/Source/GmmLib/ULT/GmmGen12dGPUResourceULT.cpp
+++ b/Source/GmmLib/ULT/GmmGen12dGPUResourceULT.cpp
@@ -1460,10 +1460,6 @@ TEST_F(CTestGen12dGPUResource, DISABLED_TestPlanarYCompressedResource)
 /// @brief ULT for Planar Ys Compressed resource
 TEST_F(CTestGen12dGPUResource, TestPlanarTile64CompressedResource)
 {
-
-    const uint32_t TileSize[TEST_BPP_MAX][2] = {
-    {256, 256}, {512, 128}, {512, 128}, {1024, 64}, {1024, 64}}; // TileYS
-
     GMM_RESCREATE_PARAMS gmmParams = {};
     gmmParams.Type                 = RESOURCE_2D;
     gmmParams.NoGfxMemory          = 1;
@@ -3124,17 +3120,6 @@ TEST_F(CTestGen12dGPUResource, DISABLED_Test2DTileYfAMFSResource)
 /// @brief ULT for MSAA Resource - adddepth MSAA, MCS surf param verificaton, compression case
 TEST_F(CTestGen12dGPUResource, DISABLED_TestColorMSAA)
 {
-    //Tile dimensions in Bytes
-    const uint32_t MCSTileSize[1][2] = {128, 32}; //MCS is TileY
-
-    const uint32_t TestDimensions[4][2] = {
-    //Input dimensions in #Tiles
-    {15, 20}, //16 Tiles x 20 <Max Width: Depth MSS crosses Pitch limit beyond this>
-    {0, 0},   //1x1x1
-    {1, 0},   //2 Tilesx1
-    {1, 1},   //2 Tiles x 2
-    };
-
     uint32_t TestArraySize[2] = {1, 5};
     uint32_t MinPitch         = 32;
 

--- a/Source/GmmLib/ULT/GmmGen9ResourceULT.cpp
+++ b/Source/GmmLib/ULT/GmmGen9ResourceULT.cpp
@@ -2353,10 +2353,6 @@ TEST_F(CTestGen9Resource, Test3DTileYsResource)
 /// @brief ULT for 3D TileYs Mipped Resource
 TEST_F(CTestGen9Resource, Test3DTileYsMippedResource)
 {
-    // Horizontal/Vertical pixel alignment
-    const uint32_t HAlign[TEST_BPP_MAX] = {64, 32, 32, 32, 16};
-    const uint32_t VAlign[TEST_BPP_MAX] = {32, 32, 32, 16, 16};
-
     const uint32_t TileSize[TEST_BPP_MAX][3] = {{64, 32, 32},
                                                 {64, 32, 32},
                                                 {128, 32, 16},


### PR DESCRIPTION
More info: https://stackoverflow.com/questions/13818803/check-for-null-before-delete-in-c-good-practice

In C this became possible after C89, code is cleaner.

```
 C89: 4.10.3.2 The free function.

The free function causes the space pointed to by ptr to be deallocated, that is, made available for further allocation. If ptr is a null pointer, no action occurs.
```