### PR TITLE
Added const reference parameters

### DIFF
--- a/Source/GmmLib/CachePolicy/GmmCachePolicy.cpp
+++ b/Source/GmmLib/CachePolicy/GmmCachePolicy.cpp
@@ -160,7 +160,7 @@ MEMORY_OBJECT_CONTROL_STATE GMM_STDCALL GmmCachePolicyGetOriginalMemoryObject(vo
 ///
 /// @return         wanted memory type
 /////////////////////////////////////////////////////////////////////////////////////
-GMM_GFX_MEMORY_TYPE GmmGetWantedMemoryType(void *pLibContext, GMM_CACHE_POLICY_ELEMENT CachePolicy)
+GMM_GFX_MEMORY_TYPE GmmGetWantedMemoryType(void *pLibContext, const GMM_CACHE_POLICY_ELEMENT &CachePolicy)
 {
     GMM_LIB_CONTEXT *pGmmLibContext = (GMM_LIB_CONTEXT *)pLibContext;
     return pGmmLibContext->GetCachePolicyObj()->GetWantedMemoryType(CachePolicy);

--- a/Source/GmmLib/CachePolicy/GmmCachePolicyCommon.cpp
+++ b/Source/GmmLib/CachePolicy/GmmCachePolicyCommon.cpp
@@ -42,7 +42,7 @@ GmmLib::GmmCachePolicyCommon::GmmCachePolicyCommon(GMM_CACHE_POLICY_ELEMENT *pCa
 ///
 /// @return         wanted memory type
 /////////////////////////////////////////////////////////////////////////////////////
-GMM_GFX_MEMORY_TYPE GmmLib::GmmCachePolicyCommon::GetWantedMemoryType(GMM_CACHE_POLICY_ELEMENT CachePolicy)
+GMM_GFX_MEMORY_TYPE GmmLib::GmmCachePolicyCommon::GetWantedMemoryType(const GMM_CACHE_POLICY_ELEMENT &CachePolicy)
 {
     GMM_GFX_MEMORY_TYPE WantedMemoryType = GMM_GFX_UC_WITH_FENCE;
     if(CachePolicy.WT)

--- a/Source/GmmLib/CachePolicy/GmmGen10CachePolicy.cpp
+++ b/Source/GmmLib/CachePolicy/GmmGen10CachePolicy.cpp
@@ -273,7 +273,7 @@ GMM_STATUS GmmLib::GmmGen10CachePolicy::SetPATInitWA()
 ///
 /// @return        PAT Idx to use in the PTE
 /////////////////////////////////////////////////////////////////////////////////////
-uint32_t GmmLib::GmmGen10CachePolicy::BestMatchingPATIdx(GMM_CACHE_POLICY_ELEMENT CachePolicy)
+uint32_t GmmLib::GmmGen10CachePolicy::BestMatchingPATIdx(const GMM_CACHE_POLICY_ELEMENT &CachePolicy)
 {
     uint32_t             i;
     uint32_t             PATIdx           = 0;

--- a/Source/GmmLib/CachePolicy/GmmGen12CachePolicy.cpp
+++ b/Source/GmmLib/CachePolicy/GmmGen12CachePolicy.cpp
@@ -408,7 +408,7 @@ EXIT:
 ///
 /// @return        PAT Idx to use in the PTE
 /////////////////////////////////////////////////////////////////////////////////////
-uint32_t GmmLib::GmmGen12CachePolicy::BestMatchingPATIdx(GMM_CACHE_POLICY_ELEMENT CachePolicy)
+uint32_t GmmLib::GmmGen12CachePolicy::BestMatchingPATIdx(const GMM_CACHE_POLICY_ELEMENT &CachePolicy)
 {
     uint32_t            i;
     uint32_t            PATIdx           = 0;

--- a/Source/GmmLib/CachePolicy/GmmGen8CachePolicy.cpp
+++ b/Source/GmmLib/CachePolicy/GmmGen8CachePolicy.cpp
@@ -312,7 +312,7 @@ GMM_STATUS GmmLib::GmmGen8CachePolicy::SetPATInitWA()
 ///
 /// @return        PAT Idx to use in the PTE
 /////////////////////////////////////////////////////////////////////////////////////
-uint32_t GmmLib::GmmGen8CachePolicy::BestMatchingPATIdx(GMM_CACHE_POLICY_ELEMENT CachePolicy)
+uint32_t GmmLib::GmmGen8CachePolicy::BestMatchingPATIdx(const GMM_CACHE_POLICY_ELEMENT &CachePolicy)
 {
     uint32_t             i;
     uint32_t             PATIdx           = 0;

--- a/Source/GmmLib/GlobalInfo/GmmInfo.cpp
+++ b/Source/GmmLib/GlobalInfo/GmmInfo.cpp
@@ -124,7 +124,7 @@ extern "C" GMM_STATUS GMM_STDCALL GmmCreateLibContext(const PLATFORM           P
                                                       const GT_SYSTEM_INFO *   pGtSysInfo,
                                                       ADAPTER_BDF              sBdf)
 #else
-extern "C" GMM_STATUS GMM_STDCALL GmmCreateLibContext(const PLATFORM Platform,
+extern "C" GMM_STATUS GMM_STDCALL GmmCreateLibContext(const PLATFORM &Platform,
                                                       const void *   pSkuTable,
                                                       const void *   pWaTable,
                                                       const void *   pGtSysInfo,
@@ -224,7 +224,7 @@ GMM_STATUS GMM_STDCALL GmmLib::GmmMultiAdapterContext::AddContext(const PLATFORM
                                                                   const char              *DeviceRegistryPath,
                                                                   uint32_t                 PhysicalAdapterIndex)
 #else
-GMM_STATUS GMM_STDCALL GmmLib::GmmMultiAdapterContext::AddContext(const PLATFORM Platform,
+GMM_STATUS GMM_STDCALL GmmLib::GmmMultiAdapterContext::AddContext(const PLATFORM &Platform,
                                                                   const void    *_pSkuTable,
                                                                   const void    *_pWaTable,
                                                                   const void    *_pGtSysInfo,
@@ -1134,7 +1134,7 @@ GMM_CACHE_POLICY *GMM_STDCALL GmmLib::Context::CreateCachePolicyCommon()
     return pGmmCachePolicy;
 }
 
-GMM_TEXTURE_CALC *GMM_STDCALL GmmLib::Context::CreateTextureCalc(PLATFORM Platform, bool Override)
+GMM_TEXTURE_CALC *GMM_STDCALL GmmLib::Context::CreateTextureCalc(const PLATFORM &Platform, bool Override)
 {
     if(!Override)
     {

--- a/Source/GmmLib/Resource/GmmResourceInfo.cpp
+++ b/Source/GmmLib/Resource/GmmResourceInfo.cpp
@@ -1740,7 +1740,7 @@ uint32_t GMM_STDCALL GmmResIsMappedCompressible(GMM_RESOURCE_INFO *pGmmResource)
 // Returns:
 //
 //-----------------------------------------------------------------------------
-uint8_t __CanSupportStdTiling(GMM_TEXTURE_INFO Surf, GMM_LIB_CONTEXT *pGmmLibContext)
+uint8_t __CanSupportStdTiling(const GMM_TEXTURE_INFO &Surf, GMM_LIB_CONTEXT *pGmmLibContext)
 {
     const __GMM_PLATFORM_RESOURCE *pPlatformResource = GMM_OVERRIDE_PLATFORM_INFO(&Surf, pGmmLibContext);
 

--- a/Source/GmmLib/inc/External/Common/CachePolicy/GmmCachePolicyGen10.h
+++ b/Source/GmmLib/inc/External/Common/CachePolicy/GmmCachePolicyGen10.h
@@ -31,7 +31,7 @@ namespace GmmLib
     {
         protected:
             /* Function prototypes */
-            uint32_t BestMatchingPATIdx(GMM_CACHE_POLICY_ELEMENT CachePolicy);
+            uint32_t BestMatchingPATIdx(const GMM_CACHE_POLICY_ELEMENT &CachePolicy);
 
         public:
             /* Constructors */

--- a/Source/GmmLib/inc/External/Common/CachePolicy/GmmCachePolicyGen12.h
+++ b/Source/GmmLib/inc/External/Common/CachePolicy/GmmCachePolicyGen12.h
@@ -60,7 +60,7 @@ namespace GmmLib
             /* Function prototypes */
             GMM_STATUS InitCachePolicy();
             uint8_t SelectNewPATIdx(GMM_GFX_MEMORY_TYPE WantedMT, GMM_GFX_MEMORY_TYPE MT1, GMM_GFX_MEMORY_TYPE MT2);
-            uint32_t BestMatchingPATIdx(GMM_CACHE_POLICY_ELEMENT CachePolicy);
+            uint32_t BestMatchingPATIdx(const GMM_CACHE_POLICY_ELEMENT &CachePolicy);
             GMM_STATUS SetPATInitWA();
             GMM_STATUS SetupPAT();
             void       SetUpMOCSTable();

--- a/Source/GmmLib/inc/External/Common/CachePolicy/GmmCachePolicyGen8.h
+++ b/Source/GmmLib/inc/External/Common/CachePolicy/GmmCachePolicyGen8.h
@@ -41,7 +41,7 @@ namespace GmmLib
                 uint64_t                    *pPTEDwordValue);
 
             /* Virtual function prototypes */
-            virtual uint32_t BestMatchingPATIdx(GMM_CACHE_POLICY_ELEMENT CachePolicy);
+            virtual uint32_t BestMatchingPATIdx(const GMM_CACHE_POLICY_ELEMENT &CachePolicy);
 
         public:
             /* Constructors */

--- a/Source/GmmLib/inc/External/Common/GmmCachePolicy.h
+++ b/Source/GmmLib/inc/External/Common/GmmCachePolicy.h
@@ -483,7 +483,7 @@ typedef union GMM_PRIVATE_PAT_REC {
 
 // Function Prototypes
 GMM_STATUS  GmmInitializeCachePolicy();
-GMM_GFX_MEMORY_TYPE GmmGetWantedMemoryType(void *pLibContext, GMM_CACHE_POLICY_ELEMENT CachePolicy);
+GMM_GFX_MEMORY_TYPE GmmGetWantedMemoryType(void *pLibContext, const GMM_CACHE_POLICY_ELEMENT &CachePolicy);
 
 // Used for GMM ULT testing.
 #ifdef __GMM_ULT

--- a/Source/GmmLib/inc/External/Common/GmmCachePolicyCommon.h
+++ b/Source/GmmLib/inc/External/Common/GmmCachePolicyCommon.h
@@ -59,7 +59,7 @@ namespace GmmLib
             GmmCachePolicyCommon(GMM_CACHE_POLICY_ELEMENT *pCachePolicy, Context *pGmmLibContext);
 
             /* Function prototypes */
-            GMM_GFX_MEMORY_TYPE GetWantedMemoryType(GMM_CACHE_POLICY_ELEMENT CachePolicy);
+            GMM_GFX_MEMORY_TYPE GetWantedMemoryType(const GMM_CACHE_POLICY_ELEMENT &CachePolicy);
 
             #define DEFINE_CP_ELEMENT(Usage, llc, ellc, l3, wt, age, aom, lecc_scc, l3_scc, scf, sso, cos, hdcl1, l3evict, segov, glbgo, uclookup, l1cc, l2cc, l4cc, coherency, l3cc, l3clos, igPAT)\
             do {                                                                                                                                                                                    \

--- a/Source/GmmLib/inc/External/Common/GmmClientContext.h
+++ b/Source/GmmLib/inc/External/Common/GmmClientContext.h
@@ -208,7 +208,7 @@ extern "C" {
                                                ADAPTER_BDF              sBdf);
 #else
 
-    GMM_STATUS GMM_STDCALL GmmCreateLibContext(const PLATFORM Platform,
+    GMM_STATUS GMM_STDCALL GmmCreateLibContext(const PLATFORM &Platform,
                                                const void *   pSkuTable,
                                                const void *   pWaTable,
                                                const void *   pGtSysInfo,

--- a/Source/GmmLib/inc/External/Common/GmmInfo.h
+++ b/Source/GmmLib/inc/External/Common/GmmInfo.h
@@ -573,7 +573,7 @@ namespace GmmLib
     #endif // __GMM_KMD__
 
     GMM_CACHE_POLICY* GMM_STDCALL CreateCachePolicyCommon();
-    GMM_TEXTURE_CALC* GMM_STDCALL CreateTextureCalc(PLATFORM Platform, bool Override);
+    GMM_TEXTURE_CALC* GMM_STDCALL CreateTextureCalc(const PLATFORM &Platform, bool Override);
     GMM_PLATFORM_INFO_CLASS *GMM_STDCALL CreatePlatformInfo(PLATFORM Platform, bool Override);
 
     private: 
@@ -653,7 +653,7 @@ typedef struct _GMM_ADAPTER_INFO_
                                                    ADAPTER_BDF              sBdf,
                                                    const char *             DeviceRegistryPath);
 #else
-        GMM_STATUS GMM_STDCALL          AddContext(const PLATFORM Platform,
+        GMM_STATUS GMM_STDCALL          AddContext(const PLATFORM &Platform,
                                                    const void *   pSkuTable,
                                                    const void *   pWaTable,
                                                    const void *   pGtSysInfo,

--- a/Source/GmmLib/inc/External/Common/GmmResourceInfo.h
+++ b/Source/GmmLib/inc/External/Common/GmmResourceInfo.h
@@ -96,7 +96,7 @@ typedef struct GMM_EXISTING_SYS_MEM_REC
 
 uint8_t     GMM_STDCALL GmmResValidateParams(GMM_RESOURCE_INFO *pResourceInfo);
 void        GMM_STDCALL GmmResGetRestrictions(GMM_RESOURCE_INFO* pResourceInfo, __GMM_BUFFER_TYPE* pRestrictions);
-uint8_t     __CanSupportStdTiling(GMM_TEXTURE_INFO Surface, GMM_LIB_CONTEXT *pGmmLibContext);
+uint8_t     __CanSupportStdTiling(const GMM_TEXTURE_INFO &Surface, GMM_LIB_CONTEXT *pGmmLibContext);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
It is advisable to use const ref read only parameters, increases readability and optimizes code generation by compiler.