### PR TITLE
Disable AuxTable test on aarch64

### DIFF
--- a/Source/GmmLib/ULT/GmmAuxTableULT.cpp
+++ b/Source/GmmLib/ULT/GmmAuxTableULT.cpp
@@ -213,7 +213,14 @@ TEST_F(CTestAuxTable, DISABLED_TestUpdateAuxTableStress)
     pGmmULTClientContext->DestroyPageTblMgrObject(mgr);
 }
 
+#if defined(__aarch64__)
+// aarch64 systems have VAs where the 48th bit is set but don't have the same
+// canonize semantics as x86_64 where bits 63-49 need to be the same as bit 48.
+// This causes this test to fault, instead we disable it in aarch64.
+TEST_F(CTestAuxTable, DISABLED_TestAuxTableContent)
+#else
 TEST_F(CTestAuxTable, TestAuxTableContent)
+#endif
 {
     GmmPageTableMgr *mgr = pGmmULTClientContext->CreatePageTblMgrObject(&DeviceCBInt, TT_TYPE::AUXTT);
 


### PR DESCRIPTION
The AuxTable test fails on aarch64 because aarch64 can return stack/heap pointers that have the 48th bit set. This combined with the canonization logic causes the test to fault since aarch64 doesn't expect the same canonization semantics as x86_64. Disabling the test is fine since canonizing the GPU pointers is fine on aarch64.
