### PR TITLE
Update cmake_minimum_required to 3.5 consisently across CMakeLists

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required (VERSION 3.1 FATAL_ERROR)
+cmake_minimum_required (VERSION 3.5 FATAL_ERROR)
 
 if (NOT DEFINED RUN_TEST_SUITE)
 option (RUN_TEST_SUITE "run test suite after install" ON)

--- a/Source/GmmLib/os_release_info.cmake
+++ b/Source/GmmLib/os_release_info.cmake
@@ -28,7 +28,7 @@ if(NOT DEFINED _os_release_info)
 set(_os_release_info TRUE)
 
 # Set cmake policies for at least this level:
-cmake_minimum_required(VERSION 2.8.12)
+cmake_minimum_required(VERSION 3.5)
 
 if(POLICY CMP0054)
     cmake_policy(SET CMP0054 NEW)


### PR DESCRIPTION
Source/GmmLib/CMakeLists.txt already is requiring CMake 3.5. 
Update remaining files to 3.5. 
This supports the compilation with cmake-4.0.0

Fixes #129 