### PR TITLE
Fix build on ARM64

### DIFF
--- a/Source/GmmLib/Linux.cmake
+++ b/Source/GmmLib/Linux.cmake
@@ -22,7 +22,7 @@
 if (${CMAKE_SYSTEM_PROCESSOR} MATCHES "^aarch")
     SET (GMMLIB_COMPILER_FLAGS_COMMON
     #general warnings
-    #-Wall
+    -Wall
     -Winit-self
     -Winvalid-pch
     -Wpointer-arith


### PR DESCRIPTION
Build the library on ARM64 failed on
`cc1plus: error：‘-Wformat-security’ ignored without ‘-Wformat’ [-Werror=format-security]`
Uncomment -Wall to fix it