### PR TITLE
Fix build error when compiled with -Wpragma-pack-suspicious-include flag

### DIFF
--- a/Android.bp
+++ b/Android.bp
@@ -109,7 +109,6 @@ cc_library_shared {
         "-Wno-missing-braces",
         "-Wno-unknown-pragmas",
         "-Wno-parentheses",
-        "-Wno-pragma-pack",
         "-fexceptions",
         "-std=c++11",
         "-fvisibility-inlines-hidden",
@@ -117,6 +116,7 @@ cc_library_shared {
         "-fno-rtti",
         "-fcheck-new",
         "-pthread",
+        "-Wpragma-pack-suspicious-include",
     ],
 
     local_include_dirs: [

--- a/Source/GmmLib/inc/External/Common/GmmResourceInfo.h
+++ b/Source/GmmLib/inc/External/Common/GmmResourceInfo.h
@@ -87,12 +87,12 @@ typedef struct GMM_EXISTING_SYS_MEM_REC
 //     Struct describing the attributes and properties of a user mode resource
 //
 //----------------------------------------------------------------------------
+// Reset packing alignment to project default
+#pragma pack(pop)
+
 #ifndef _WIN32
     #include "../Linux/GmmResourceInfoLin.h"
 #endif
-
-// Reset packing alignment to project default
-#pragma pack(pop)
 
 uint8_t     GMM_STDCALL GmmResValidateParams(GMM_RESOURCE_INFO *pResourceInfo);
 void        GMM_STDCALL GmmResGetRestrictions(GMM_RESOURCE_INFO* pResourceInfo, __GMM_BUFFER_TYPE* pRestrictions);

--- a/Source/GmmLib/inc/External/Common/GmmResourceInfoExt.h
+++ b/Source/GmmLib/inc/External/Common/GmmResourceInfoExt.h
@@ -191,9 +191,6 @@ typedef struct GmmLibContext GMM_LIB_CONTEXT;
 // Place holder for GMM_RESOURCE_FLAG definition.
 //---------------------------------------------------------------------------
 #include "GmmResourceFlags.h"
-#if defined __linux__
-    #include "External/Linux/GmmResourceInfoLinExt.h"
-#endif
 
 //==========================================================================
 // typedef:
@@ -768,6 +765,9 @@ void                    GmmResMemcpyThroughClientCtxt(void *pDst, void *pSrc);
 // Reset packing alignment to project default
 #pragma pack(pop)
 
+#if defined __linux__
+    #include "External/Linux/GmmResourceInfoLinExt.h"
+#endif
 #ifdef __cplusplus
 }
 #endif /*__cplusplus*/

--- a/Source/GmmLib/inc/External/Linux/GmmResourceInfoLin.h
+++ b/Source/GmmLib/inc/External/Linux/GmmResourceInfoLin.h
@@ -25,6 +25,9 @@ OTHER DEALINGS IN THE SOFTWARE.
 #ifdef __cplusplus
 #include "../Common/GmmResourceInfoCommon.h"
 
+// Set packing alignment
+#pragma pack(push, 8)
+
 /////////////////////////////////////////////////////////////////////////////////////
 /// @file GmmResourceInfoLin.h
 /// @brief This file contains the functions and members of GmmResourceInfo that is
@@ -57,6 +60,10 @@ namespace GmmLib
     typedef GmmResourceInfoLin GmmResourceInfo;
 
 } // namespace GmmLib
+
+// Reset packing alignment to project default
+#pragma pack(pop)
+
 #else
     typedef struct GmmResourceInfo GmmResourceInfo;
 #endif // #ifdef __cplusplus

--- a/Source/GmmLib/inc/External/Linux/GmmResourceInfoLinExt.h
+++ b/Source/GmmLib/inc/External/Linux/GmmResourceInfoLinExt.h
@@ -27,6 +27,9 @@ OTHER DEALINGS IN THE SOFTWARE.
 extern "C" {
 #endif /*__cplusplus*/
 
+// Set packing alignment
+#pragma pack(push, 8)
+
 typedef struct {
     int(*pfnAllocate)(void *bufMgr, size_t size, size_t alignment, void **bo, void **cpuAddr, uint64_t *gpuAddr);
     void(*pfnDeallocate)(void *bo);
@@ -88,6 +91,9 @@ typedef struct GMM_UMD_SYNCCONTEXT_REC
     HANDLE              BBFenceObj;             // BatchBuffer Last Fence, for CPU to wait on before destroying TT pages
     uint64_t            BBLastFence;            // BatchBuffer Last Fence for TT
 } GMM_UMD_SYNCCONTEXT;
+
+// Reset packing alignment to project default
+#pragma pack(pop)
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
When gmmlib is compiled with -Wpragma-pack-suspicious-include, following build issue is seen

Source/GmmLib/inc/External/Common/GmmResourceInfoExt.h:195:14:

error: non-default #pragma pack value changes the alignment of \ struct or union members in the included file \
[-Werror,-Wpragma-pack-suspicious-include] \
    #include "External/Linux/GmmResourceInfoLinExt.h"

Source/GmmLib/inc/External/Common/GmmResourceInfo.h:91:14: \ error: non-default #pragma pack value changes the alignment of struct or \ union members in the included file [-Werror,-Wpragma-pack-suspicious-include]
    #include "../Linux/GmmResourceInfoLin.h"

Source/GmmLib/inc/External/Common/GmmResourceInfo.h:30:9: note: previous \ '#pragma pack' directive that modifies alignment is here
    #pragma pack(push, 8)

Move the header include outside the pragma definition and add the pragma packing as part of the headers.